### PR TITLE
Potential fix for code scanning alert no. 38: Use of externally-controlled format string

### DIFF
--- a/server/src/services/aicli-session-manager.js
+++ b/server/src/services/aicli-session-manager.js
@@ -196,7 +196,7 @@ export class AICLISessionManager extends EventEmitter {
           await sessionPersistence.removeSession(sessionId);
           console.log(`💾 Session ${sessionId} removed from persistent storage`);
         } catch (error) {
-          console.error(`❌ Failed to remove session ${sessionId} from persistence:`, error);
+          console.error('❌ Failed to remove session %s from persistence:', sessionId, error);
         }
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/38](https://github.com/dock108/aicli-companion/security/code-scanning/38)

To fix the problem, we should avoid directly interpolating untrusted data (`sessionId`) into the log message template. Instead, we should use a static format string and pass the untrusted data as a separate argument, ensuring that it is treated as a value and not as part of the format string. In Node.js, this can be done by using a format specifier (e.g., `%s`) in the log message and passing `sessionId` as an argument. This approach prevents any format string injection or log manipulation. The change should be made in `server/src/services/aicli-session-manager.js` at line 199, replacing the template literal with a format string and arguments.

No new imports or methods are required, as `console.error` supports format specifiers natively.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
