### PR TITLE
Potential fix for code scanning alert no. 39: Use of externally-controlled format string

### DIFF
--- a/server/src/services/push-notification.js
+++ b/server/src/services/push-notification.js
@@ -247,7 +247,7 @@ class PushNotificationService {
         // Record telemetry
         getTelemetryService().recordMessageSent(clientId, 'push_notification', true);
       } else {
-        console.error(`❌ Push notification failed for client ${clientId}:`, result.error);
+        console.error('❌ Push notification failed for client %s:', clientId, result.error);
         // Record telemetry
         getTelemetryService().recordMessageSent(clientId, 'push_notification', false);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/39](https://github.com/dock108/aicli-companion/security/code-scanning/39)

To fix this problem, we should ensure that user-controlled data is not interpreted as a format string by `console.error`. The best way to do this is to avoid including user input directly in the format string. Instead, use a static format string with a `%s` placeholder, and pass the user input as a separate argument. This ensures that any format specifiers in the user input are not interpreted by the logging function. Specifically, in `server/src/services/push-notification.js`, line 250 should be changed from:
```js
console.error(`❌ Push notification failed for client ${clientId}:`, result.error);
```
to:
```js
console.error('❌ Push notification failed for client %s:', clientId, result.error);
```
No additional imports or method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
