### PR TITLE
Potential fix for code scanning alert no. 56: Use of externally-controlled format string

### DIFF
--- a/server/src/services/aicli-session-manager.js
+++ b/server/src/services/aicli-session-manager.js
@@ -488,7 +488,8 @@ export class AICLISessionManager extends EventEmitter {
           console.log(`💾 Session ${sessionId} conversation start persisted`);
         } catch (error) {
           console.warn(
-            `⚠️ Failed to persist conversation start for session ${sessionId}:`,
+            '⚠️ Failed to persist conversation start for session %s:',
+            sessionId,
             error.message
           );
         }


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/56](https://github.com/dock108/aicli-companion/security/code-scanning/56)

To fix the problem, we should avoid directly interpolating user-controlled data into the format string of logging functions. Instead, we should use a static format string and pass the user-controlled value as a separate argument. This prevents any accidental interpretation of format specifiers and makes the log message structure explicit. Specifically, in `server/src/services/aicli-session-manager.js`, line 491, change the template literal to a format string with a `%s` placeholder, and pass `sessionId` as a separate argument. No new imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
