### PR TITLE
Potential fix for code scanning alert no. 40: Use of externally-controlled format string

### DIFF
--- a/server/src/services/session-persistence.js
+++ b/server/src/services/session-persistence.js
@@ -505,7 +505,7 @@ export class SessionPersistenceService {
       console.log(`🗑️ Removed message buffer for session ${sessionId}`);
     } catch (error) {
       if (error.code !== 'ENOENT') {
-        console.error(`❌ Failed to remove message buffer for session ${sessionId}:`, error);
+        console.error('❌ Failed to remove message buffer for session %s:', sessionId, error);
       }
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/40](https://github.com/dock108/aicli-companion/security/code-scanning/40)

To fix the problem, we should avoid directly interpolating the untrusted `sessionId` into the log message string. Instead, we should use a static format string and pass the untrusted value as a separate argument to `console.error`. This ensures that any format specifiers in `sessionId` are not interpreted as part of the format string. Specifically, in `server/src/services/session-persistence.js`, line 508, change:

```js
console.error(`❌ Failed to remove message buffer for session ${sessionId}:`, error);
```

to

```js
console.error('❌ Failed to remove message buffer for session %s:', sessionId, error);
```

No new imports or definitions are needed, as this is standard Node.js logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
