### PR TITLE
Potential fix for code scanning alert no. 61: Use of externally-controlled format string

### DIFF
--- a/server/src/services/push-notification.js
+++ b/server/src/services/push-notification.js
@@ -380,7 +380,7 @@ class PushNotificationService {
       const result = await this.sendNotification(device.token, notification);
 
       if (!result.success) {
-        console.error(`❌ Error notification failed for client ${clientId}:`, result.error);
+        console.error('❌ Error notification failed for client %s:', clientId, result.error);
       }
     } catch (error) {
       console.error('Error sending error notification:', error);


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/61](https://github.com/dock108/aicli-companion/security/code-scanning/61)

To fix this issue, we should ensure that user-controlled data is not used directly as the format string in logging functions like `console.error`. The best practice is to use a fixed format string with a `%s` placeholder and pass the user-controlled value as a separate argument. This prevents any format specifiers in the user input from being interpreted by the logging function. Specifically, in `server/src/services/push-notification.js`, line 383 should be changed from:

```js
console.error(`❌ Error notification failed for client ${clientId}:`, result.error);
```

to:

```js
console.error('❌ Error notification failed for client %s:', clientId, result.error);
```

No new imports or method definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
