### PR TITLE
Potential fix for code scanning alert no. 72: Incomplete URL substring sanitization

### DIFF
--- a/server/src/test/services/tunnel.test.js
+++ b/server/src/test/services/tunnel.test.js
@@ -404,8 +404,12 @@ test('TunnelService', async (t) => {
 
   await t.test('should generate connection QR without auth token', () => {
     const qr = tunnelService.generateConnectionQR('https://test.ngrok.io', null);
-    assert.ok(qr.includes('https://test.ngrok.io'));
-    assert.ok(!qr.includes('?token='));
+    // Extract the URL from the QR output and check it matches exactly
+    const urlMatch = qr.match(/https?:\/\/[^\s]+/);
+    assert.ok(urlMatch, 'QR output should contain a URL');
+    const parsedUrl = new URL(urlMatch[0]);
+    assert.strictEqual(parsedUrl.href, 'https://test.ngrok.io/');
+    assert.ok(!parsedUrl.searchParams.has('token'));
     assert.ok(qr.includes('Scan QR or use URL below to connect'));
   });
 


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/72](https://github.com/dock108/aicli-companion/security/code-scanning/72)

To fix the problem, we should avoid using `.includes('https://test.ngrok.io')` to check for the presence of the URL. Instead, we should extract the URL from the QR code output and parse it to ensure it matches the expected value. In this test, the QR code output appears to be a string that includes the URL, so we can use a regular expression to extract the URL, then use the `URL` constructor to parse and compare it. This change should be made in the test block for "should generate connection QR without auth token" (lines 405–410). We will also need to add an import for the `URL` class if not already present (in Node.js, it's global, but for clarity, we can use it directly).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
