### PR TITLE
Potential fix for code scanning alert no. 74: Regular expression injection

### DIFF
--- a/server/src/services/command-security.js
+++ b/server/src/services/command-security.js
@@ -368,6 +368,11 @@ export class CommandSecurityService extends EventEmitter {
     const isConfiguredDestructive = this.config.destructiveCommands.some((pattern) => {
       if (command.includes(pattern)) return true;
       try {
+        // Only use as regex if pattern is safe
+        if (!isSafeRegex(pattern)) {
+          logger.warn(`Destructive command pattern rejected as unsafe: ${pattern}`);
+          return false;
+        }
         const regex = new RegExp(pattern);
         return regex.test(command);
       } catch {


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/aicli-companion/security/code-scanning/74](https://github.com/dock108/aicli-companion/security/code-scanning/74)

To fix the problem, we should ensure that any pattern from untrusted sources (such as environment variables or user options) is either sanitized or validated before being used to construct a regular expression. The best approach is to use the existing `isSafeRegex` function to validate the pattern before constructing the regex. If the pattern is not safe, we should skip regex matching for that pattern. This change should be made in the `isDestructiveCommand` method, specifically before the line `const regex = new RegExp(pattern);`. If the pattern is not safe, we should return `false` for that pattern. No changes to imports are needed, as `isSafeRegex` is already defined and available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
